### PR TITLE
build.rs: Use pkg-config to find header search paths for bindgen.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ uuid = "1.0.0"
 [features]
 default = []
 deprecated = []
+pkg-config = ["libblkid-rs-sys/pkg-config"]
+static = ["pkg-config", "libblkid-rs-sys/static"]
 
 [lints.rust]
 warnings = { level = "deny" }

--- a/libblkid-rs-sys/Cargo.toml
+++ b/libblkid-rs-sys/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["storage"]
 
 [build-dependencies]
 cc = "1.0.45"
+pkg-config = "0.3.31"
+cfg-if = "1.0.0"
 
 [build-dependencies.bindgen]
 default-features = false
@@ -30,3 +32,7 @@ nonstandard_style = { level = "deny", priority = 4 }
 [lints.clippy]
 all = { level = "deny" }
 cargo = { level = "deny" , priority = 1}
+
+[features]
+static = ["pkg-config"]
+pkg-config = []


### PR DESCRIPTION
Fairly straightforward build.rs changes. Features are present with the idea that this could be upstreamed without breaking anything for upstream uses. 